### PR TITLE
Main

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,8 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32doit-devkit-v1]
-platform = espressif32
+platform = espressif32@^5.3.0
+; ...not yet compatible with 6.x
 board = esp32doit-devkit-v1
 framework = espidf
 build_unflags = -Werror=all


### PR DESCRIPTION
explicit dependency versioning because older espressif32 5.x is needed at the moment (probably last build with 5.2 or 5.3 in december; build is successful with recent maintenanace release 5.4.0; not yet tested on target)